### PR TITLE
Setup Heroku deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     docker:
       - image: circleci/ruby:2.7.5-node-browsers
         environment:
-          BUNDLER_VERSION: 2.3.7
+          BUNDLER_VERSION: 2.2.33
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
           BUNDLE_PATH: vendor/bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,5 +324,8 @@ DEPENDENCIES
   webdrivers
   webpacker (~> 5.0)
 
+RUBY VERSION
+   ruby 2.7.5p203
+
 BUNDLED WITH
-   2.3.7
+   2.2.33

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+release: bin/rails db:seed
+web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV

--- a/bin/bundle
+++ b/bin/bundle
@@ -39,7 +39,7 @@ m = Module.new do
 
   def gemfile
     gemfile = ENV["BUNDLE_GEMFILE"]
-    return gemfile if gemfile.present?
+    return gemfile if gemfile && !gemfile.empty?
 
     File.expand_path("../../Gemfile", __FILE__)
   end


### PR DESCRIPTION
Sets up Heroku deployment by changing the Bundler version, adding a Procfile, and changing a line of code in `bin/bundle` that causes a build error in Heroku.